### PR TITLE
Initializing logger every time is unnecessary

### DIFF
--- a/src/Infrastructure/NetDevPL.Infrastructure.SharedKernel/Logger.cs
+++ b/src/Infrastructure/NetDevPL.Infrastructure.SharedKernel/Logger.cs
@@ -4,38 +4,30 @@ namespace NetDevPLWeb.SharedKernel
 {
     public static class Logger
     {
+        static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        
         public static void Fatal(string message)
         {
-            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
             logger.Fatal(message);
         }
 
         public static void Fatal(Exception excepion)
         {
-            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
             logger.Fatal(excepion);
         }
 
         public static void Info(string message)
         {
-            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
             logger.Info(message);
         }
 
         public static void Debug(string message)
         {
-            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
             logger.Debug(message);
         }
 
         public static void Warning(string message)
         {
-            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
             logger.Warn(message);
         }
     }


### PR DESCRIPTION
GetCurrentClassLogger is not performant and should be cached