### PR TITLE
CHanges in the mechanism responsible for reading URl to a post

### DIFF
--- a/src/Apps/NetDevPL.Apps.BackgoundJobs/blogsConfig.json
+++ b/src/Apps/NetDevPL.Apps.BackgoundJobs/blogsConfig.json
@@ -46,7 +46,8 @@
     },
     {
         "Url": "http://www.michalkomorowski.com/",
-        "Rss": "http://feeds.feedburner.com/BlogMichalaKomorowskiego",
-        "Title": "Michał Komorowski -  The blog about programming, working in IT and not only"
+        "Rss": "http://www.michalkomorowski.com/feeds/posts/default?alt=rss&redirect=false",
+        "Title": "Michał Komorowski -  The blog about programming, working in IT and not only",
+        "IndexOfLinkToPost":  "0"
     }
 ]

--- a/src/Features/NetDevPL.Features.Blogs/BlogDataProvider.cs
+++ b/src/Features/NetDevPL.Features.Blogs/BlogDataProvider.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.ServiceModel.Syndication;
+
 using NetDevPL.Infrastructure.Helpers;
+
 
 namespace NetDevPL.Features.Blogs
 {
@@ -11,12 +15,26 @@ namespace NetDevPL.Features.Blogs
             foreach (var blog in blogs)
             {
                 var rssData = RssProvider.GetItemsFromRss(blog.Rss);
-                var blogPosts = rssData.Select(item => new BlogPost {Title = item.Title.Text, Url = item.Id, PublishDate = item.PublishDate.UtcDateTime});
+                var blogPosts = rssData.Select(item => new BlogPost {Title = item.Title.Text, Url = GetUrl(blog, item), PublishDate = item.PublishDate.UtcDateTime});
 
                 blog.BlogPosts = blogPosts;
             }
 
             return blogs;
+        }
+
+        private string GetUrl(Blog blog, SyndicationItem item)
+        {
+            var url = item.Id;
+
+            if (blog.IndexOfLinkToPost.HasValue)
+            {
+                var index = blog.IndexOfLinkToPost.Value;
+                if (item.Links != null && item.Links.Any() && index < item.Links.Count)
+                    url = item.Links[index].Uri.AbsoluteUri;
+            }
+
+            return url;
         }
     }
 }

--- a/src/Features/NetDevPL.Features.Blogs/BlogDataSnapshot.cs
+++ b/src/Features/NetDevPL.Features.Blogs/BlogDataSnapshot.cs
@@ -26,6 +26,12 @@ namespace NetDevPL.Features.Blogs
         public string Url { get; set; }
         public string Rss { get; set; }
         public string Title { get; set; }
+        /// <summary>
+        /// By default an url for a post is read from <seealso cref="System.ServiceModel.Syndication.SyndicationItem.Id"/> property.
+        /// If this property is set, it will be read from a given index in the
+        /// <seealso cref="System.ServiceModel.Syndication.SyndicationItem.Links"/> collection. 
+        /// </summary>
+        public int? IndexOfLinkToPost { get; set; }
         public IEnumerable<BlogPost> BlogPosts { get; set; }
     }
 


### PR DESCRIPTION
Before my changes BlogDataProvider assumed that SyndicationItem.Id contains an url of a post. However it is not always true. I changed the implementation so that an url can be retrieved from SyndicationItem.Links collection. BlogDataProvider will do so if Blog.IndexOfLinkToPost is set to a correct value.