### PR TITLE
Fix new year ArgumentOutOfRangeException in facebook's posts

### DIFF
--- a/src/Apps/NetDevPL.Apps.WebApp/Features/Facebook/FacebookPostsViewModel.cs
+++ b/src/Apps/NetDevPL.Apps.WebApp/Features/Facebook/FacebookPostsViewModel.cs
@@ -1,17 +1,17 @@
-﻿using Gmtl.HandyLib;
+﻿using System.Collections.Generic;
 using NetDevPL.Features.Facebook;
 
 namespace NetDevPLWeb.Features.Facebook
 {
     public class FacebookPostsViewModel
     {
-        public FacebookPostsViewModel(string pageName, HLListPage<FacebookPost> posts)
+        public FacebookPostsViewModel(string pageName, List<FacebookPost> posts)
         {
             Posts = posts;
             PageTitle = pageName;
         }
 
-        public HLListPage<FacebookPost> Posts { get; set; }
+        public List<FacebookPost> Posts { get; set; }
 
         public string PageTitle { get; set; }
     }

--- a/src/Apps/NetDevPL.Apps.WebApp/Features/Facebook/Views/facebookPosts.cshtml
+++ b/src/Apps/NetDevPL.Apps.WebApp/Features/Facebook/Views/facebookPosts.cshtml
@@ -1,4 +1,5 @@
-﻿@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<NetDevPLWeb.Features.Facebook.FacebookPostsViewModel>
+﻿@using System.Linq
+@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<NetDevPLWeb.Features.Facebook.FacebookPostsViewModel>
 
 <div class="jumbotron clearfix">
     <h2>@Model.PageTitle</h2>
@@ -17,6 +18,12 @@
                 <span class="pull-left">@post.CreateDate.ToString("yyyy-MM-dd HH:mm")</span>
                 <span class="pull-right">Liczba polubień: <span class="label label-default">@post.Likes</span></span>
             </div>
+        </div>
+    }
+    @if (!Model.Posts.Any())
+    {
+        <div class="panel panel-info">
+            <div class="panel-body">Nie znaleziono żadnych postów w wybranym zakresie daty</div> 
         </div>
     }
 </div>

--- a/src/Apps/NetDevPL.Apps.WebApp/NetDevPL.Apps.WebApp.csproj
+++ b/src/Apps/NetDevPL.Apps.WebApp/NetDevPL.Apps.WebApp.csproj
@@ -35,10 +35,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Gmtl.HandyLib, Version=1.0.20.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Gmtl.HandyLib.1.0.20\lib\net45\Gmtl.HandyLib.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Mono.Posix, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Mono.Posix.4.0.0.0\lib\net40\Mono.Posix.dll</HintPath>
       <Private>True</Private>
@@ -180,7 +176,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\packages\Nancy.Viewengines.Razor.1.4.3\build\Nancy.ViewEngines.Razor.targets" Condition="Exists('..\..\..\packages\Nancy.Viewengines.Razor.1.4.3\build\Nancy.ViewEngines.Razor.targets')" />
   <PropertyGroup>
-    <PreBuildEvent>IF EXIST "$(ProjectDir)\sensitive-data.config" (copy /Y $(ProjectDir)\sensitive-data.config $(TargetDir)) ELSE (copy /Y $(ProjectDir)\sensitive-data.config.sample $(TargetDir)\sensitive-data.config )</PreBuildEvent>
+    <PreBuildEvent>IF EXIST "$(ProjectDir)\sensitive-data.config" (copy /Y "$(ProjectDir)\sensitive-data.config" "$(TargetDir)") ELSE (copy /Y "$(ProjectDir)\sensitive-data.config.sample" "$(TargetDir)\sensitive-data.config" )</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Features/NetDevPL.Features.Facebook/Repository.cs
+++ b/src/Features/NetDevPL.Features.Facebook/Repository.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Gmtl.HandyLib;
 using MongoDB.Driver;
 using NetDevPL.Infrastructure.MongoDB;
 
@@ -13,7 +12,7 @@ namespace NetDevPL.Features.Facebook
         readonly MongoDBProvider<FacebookUser> usersProvider = new MongoDBProvider<FacebookUser>("netdevpl", "facebookUsers");
         readonly MongoDBProvider<FacebookLike> likesProvider = new MongoDBProvider<FacebookLike>("netdevpl", "facebookLikes");
 
-        public HLListPage<FacebookPost> PostsGetList(PostFilter filter)
+        public List<FacebookPost> PostsGetList(PostFilter filter)
         {
             var defaultFilter = Builders<FacebookPost>.Filter.Empty;
             var defaultSorting = Builders<FacebookPost>.Sort.Descending(p => p.CreateDate);
@@ -43,9 +42,7 @@ namespace NetDevPL.Features.Facebook
                 }
             }
 
-            var posts = postsProvider.Collection.Find(defaultFilter).Sort(defaultSorting).ToList();
-
-            return new HLListPage<FacebookPost>(posts, posts.Count, 1, posts.Count);
+            return postsProvider.Collection.Find(defaultFilter).Sort(defaultSorting).ToList();
         }
 
         public List<FacebookUser> UsersGetList()


### PR DESCRIPTION
Since there are no posts yet for facebook in this year ([http://netdevelopers.pl/facebook/top-current-year](http://netdevelopers.pl/facebook/top-current-year)) server currently throws an exception System.ArgumentOutOfRangeException in HLListPage.cs:25. I've decided not to use this class (sorry  @pawelklimczyk :D), change this to List<> and prompt user that there are no posts found.