### PR TITLE
Fixed issue with mongo db

### DIFF
--- a/src/Infrastructure/NetDevPL.Infrastructure.MongoDB/MongoDBProvider.cs
+++ b/src/Infrastructure/NetDevPL.Infrastructure.MongoDB/MongoDBProvider.cs
@@ -29,6 +29,8 @@ namespace NetDevPL.Infrastructure.MongoDB
                 cm.AutoMap();
                 cm.SetIgnoreExtraElements(true);
             });
+
+            BsonDefaults.GuidRepresentation = GuidRepresentation.Standard;
         }
 
         public IMongoCollection<T> Collection => database.GetCollection<T>(collectionName);


### PR DESCRIPTION
Fixes startup exception with message `The GuidRepresentation for the reader is CSharpLegacy, which requires the binary sub type to be UuidLegacy, not UuidStandard.`